### PR TITLE
Mission 08 fixes

### DIFF
--- a/DATA/MISSIONS/M08/m08.ini
+++ b/DATA/MISSIONS/M08/m08.ini
@@ -977,7 +977,7 @@ Act_DeactTrig = near_final_jumphole
 system = Ku04
 nickname = goto_base
 SetPriority = ALWAYS_EXECUTE
-MakeNewFormation = transport_bretonia, Ozu, Juni, bd_1, bd_2, bd_3, add_followers
+MakeNewFormation = transport_bretonia, Ozu, Juni, bd_1, bd_2, bd_3
 GotoVec = goto, -28187, 0, -68147, 500, true, -1
 
 [Trigger]

--- a/DATA/MISSIONS/M08/m08.ini
+++ b/DATA/MISSIONS/M08/m08.ini
@@ -586,6 +586,8 @@ Act_StartDialog = meet_more_dragons
 Act_GiveObjList = Ozu, goto_hole
 Act_ActTrig = set_navmarker_to_jumphole
 Act_PlayMusic = music_reveal_and_exposition, none, none, none
+Act_SetNNObj = null, OBJECTIVE_HISTORY
+Act_PobjIdle = no_params
 
 [Trigger]
 nickname = set_navmarker_to_jumphole


### PR DESCRIPTION
Tekagis Transport seems to be flying normal speed for ages because of an issue with the formation. I removed one label of formation members that makes no single appearance in the entire game. Locally I tested this once and it resolved the issue. More test runs should be done however!

Second, the player will shoot past the Dragon Escorts in New Tokyo once meeting them, because the maneuver is not stopped. I added a full stop there to force the player to stay with the others.