### PR TITLE
Make NPC Transport Cargo Pods selectable in WireFrame Windows

### DIFF
--- a/DATA/EQUIPMENT/select_equip.ini
+++ b/DATA/EQUIPMENT/select_equip.ini
@@ -192,6 +192,7 @@ explosion_arch = explosion_large_debris
 
 [CargoPod]
 nickname = cargopod_blue
+ids_name = 1083
 DA_archetype = Equipment\models\commodities\crates\pod_blue.3db
 material_library = Equipment\models\cargo_pods.mat
 LODranges = 0, 1500
@@ -203,6 +204,7 @@ debris_type = debris_pod_blue
 
 [CargoPod]
 nickname = cargopod_green
+ids_name = 1083
 DA_archetype = Equipment\models\commodities\crates\pod_green.3db
 material_library = Equipment\models\cargo_pods.mat
 LODranges = 0, 1500
@@ -214,6 +216,7 @@ debris_type = debris_pod_green
 
 [CargoPod]
 nickname = cargopod_yellow
+ids_name = 1083
 DA_archetype = Equipment\models\commodities\crates\pod_yellow.3db
 material_library = Equipment\models\cargo_pods.mat
 LODranges = 0, 1500
@@ -225,6 +228,7 @@ debris_type = debris_pod_yellow
 
 [CargoPod]
 nickname = cargopod_red
+ids_name = 1083
 DA_archetype = Equipment\models\commodities\crates\pod_red.3db
 material_library = Equipment\models\cargo_pods.mat
 LODranges = 0, 1500
@@ -236,6 +240,7 @@ debris_type = debris_pod_red
 
 [CargoPod]
 nickname = cargopod_grey
+ids_name = 1083
 DA_archetype = Equipment\models\commodities\crates\pod_grey.3db
 material_library = Equipment\models\cargo_pods.mat
 LODranges = 0, 1500
@@ -247,6 +252,7 @@ debris_type = debris_pod_grey
 
 [CargoPod]
 nickname = cargopod_white
+ids_name = 1083
 DA_archetype = Equipment\models\commodities\crates\pod_white.3db
 material_library = Equipment\models\cargo_pods.mat
 LODranges = 0, 1500
@@ -258,6 +264,7 @@ debris_type = debris_pod_white
 
 [CargoPod]
 nickname = cargopod_drab
+ids_name = 1083
 DA_archetype = Equipment\models\commodities\crates\pod_drab.3db
 material_library = Equipment\models\cargo_pods.mat
 LODranges = 0, 1500


### PR DESCRIPTION
NPC transport/train cargo pods are not selectable in target wireframe window. This is because they have no assigned IDS Name (0). It could be however very useful to make them selectable.

This PR gave them the name "Cargo Space" because there is simply no fitting resource in the entire vanilla game for these.
Alternative they could be called " " (ids 1) to make it not read weird and keep the name just empty.

