### PR TITLE
Add missing LOD Range entry to track_ring

### DIFF
--- a/DATA/SOLAR/solararch.ini
+++ b/DATA/SOLAR/solararch.ini
@@ -1034,6 +1034,7 @@ DA_archetype = solar\dockable\track_ring.3db
 material_library = solar\Solar_mat_misc02.mat
 material_library = fx\envmapbasic.mat
 envmap_material = envmapbasic
+LODranges = 0, 8000
 mass = 10000
 loadout = track_ring
 solar_radius = 600


### PR DESCRIPTION
This prevents track rings from being visible across the entire system (if the hex edit is set to disable early clipping of small space objects).

I used the range of 8k because that appears as a sensible default to me by FL default ranges. The track ring comes without any LOD versions.